### PR TITLE
Fix linux compilation

### DIFF
--- a/src/restclient.cpp
+++ b/src/restclient.cpp
@@ -3,6 +3,7 @@
 #include <string>
 #include <map>
 #include <iterator>
+#include <string.h>
 #include <curl/curl.h>
 #include <curl/easy.h>
 


### PR DESCRIPTION
memcpy function defined in string.h header
